### PR TITLE
Fix for command arguments compact form

### DIFF
--- a/SmartSVGPath.js
+++ b/SmartSVGPath.js
@@ -133,6 +133,7 @@ this["SmartSVGPath"] = (function () {   'use strict';
         d = d.replace( /-/g, ' - ' );            // Space delimit 'negative' signs. (maybe excessive but safe)
         d = d.replace( /-\s+/g, '-' );           // Remove space to the right of 'negative's.
         d = d.replace( /([a-zA-Z])/g, ' $1 ' );  // Space delimit the command.
+        d = d.replace( /((\s|\d)\.\d+)(\.\d)/g, '$1 $3' );
         d = d.replace( /\s+/g, ' ' ).trim();     // Compact excess whitespace.
         return d;
     };


### PR DESCRIPTION
Hi there!

I spotted that you library ruins &lt;path d=""> string if there are command arguments in their compact form exist. As per [documentation](https://www.w3.org/TR/SVG/paths.html#PathDataBNF), it's fine to have "M 0.6.5" command which actually means "M 0.6 0.5". My patch fixes this case.

Could you accept it and release a new version, please?
